### PR TITLE
Add precompilation

### DIFF
--- a/src/GreatCircle.jl
+++ b/src/GreatCircle.jl
@@ -1,5 +1,7 @@
 module GreatCircle
 
+__precompile__()
+
 using Geodesy: LatLon
 export great_distance, great_circle
 


### PR DESCRIPTION
Hi, I'd like to use GreatCircle for reverse Vincenty calculations in my package [SAC](https://github.com/anowacki/SAC.jl).  I currently precompile, but this won't be possible if I REQUIRE GreatCircle.  This is just a cheeky PR to see if you might be amenable to enabling precompilation.  I can't find any problems in testing with this, and the code doesn't seem to have any dependencies which would prevent it (noting that Geodesy is precompiled).  Equally, you might rather not choose this option, which is of course your prerogative.